### PR TITLE
include the unsupported directory

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -29,6 +29,7 @@ class EigenConan(ConanFile):
         self.copy("COPYING.*", dst="licenses", src=self.source_subfolder,
                   ignore_case=True, keep_path=False)
         self.copy(pattern="*", dst="include/Eigen", src="{}/Eigen".format(self.source_subfolder))
+        self.copy(pattern="*", dst="include/unsupported", src="{}/unsupported".format(self.source_subfolder))
 
     def package_id(self):
         self.info.header_only()


### PR DESCRIPTION
Eigen ships a collection of "unsupported" modules that are _provided "as is", without any support_; see the [reference page](http://eigen.tuxfamily.org/dox/unsupported/index.html) and the [overview paragraph](http://eigen.tuxfamily.org/index.php?title=Main_Page#Documentation) in the main doc/

An example of a project that relies on the unsupported modules is [libigl](https://github.com/libigl/libigl/search?q="unsupported%2FEigen")
