### PR TITLE
Unsupported Eigen added

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -33,10 +33,12 @@ class EigenConan(ConanFile):
     def package(self):
         self.copy("COPYING.*", dst="licenses", src=self._source_subfolder)
         self.copy("*", dst=os.path.join("include", "eigen3", "Eigen"), src=os.path.join(self._source_subfolder, "Eigen"))
+        self.copy("*", dst=os.path.join("include", "unsupported", "unsupported", "Eigen"), src=os.path.join(self._source_subfolder, "unsupported", "Eigen"))
         os.remove(os.path.join(self.package_folder, "include", "eigen3", "Eigen", "CMakeLists.txt"))
+        os.remove(os.path.join(self.package_folder, "include", "unsupported", "unsupported", "Eigen", "CMakeLists.txt"))
 
     def package_info(self):
-        self.cpp_info.includedirs = ['include/eigen3']
+        self.cpp_info.includedirs = ['include/eigen3', 'include/unsupported']
         if self.options.EIGEN_USE_BLAS:
             self.cpp_info.defines.append("EIGEN_USE_BLAS")
 

--- a/test_package/test_package.cpp
+++ b/test_package/test_package.cpp
@@ -1,5 +1,7 @@
 #include <iostream>
 #include <Eigen/Core>
+#include <unsupported/Eigen/MatrixFunctions>
+
 
 int main(void)
 {


### PR DESCRIPTION
I have added support for the `unsupported` Eigen modules, without them some libraries do not compile (e.g. OpenCV structured_light, rgbd, etc.):

```
/home/mads/gplaza/.conan/data/opencv/4.1.1/conan/stable/build/57186bf17ddd3392314d0ec5cb6c813157525c8c/contrib/modules/rgbd/src/odometry.cpp:21:12: fatal error: unsupported/Eigen/MatrixFunctions: does not exist
#  include <unsupported/Eigen/MatrixFunctions>
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
source_subfolder/modules/rgbd/CMakeFiles/opencv_rgbd.dir/build.make:173: recipe for target 'source_subfolder/modules/rgbd/CMakeFiles/opencv_rgbd.dir/src/odometry.cpp.o' failed
``` 