### PR TITLE
Change package name to Eigen3

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -47,4 +47,5 @@ class EigenConan(ConanFile):
         self.info.header_only()
 
     def package_info(self):
+        self.cpp_info.name = "Eigen3"
         self.cpp_info.includedirs = ['include/eigen3', 'include/unsupported']


### PR DESCRIPTION
When looking for Eigen version 3.x.y, the CMake way is to use `find_package(Eigen3)`, so this change is required to get `find_package*` generators to work properly. That said the expected target is `Eigen3::Eigen` is generally expected and this change makes `Eigen3::Eigen3` available instead, so all in all it's only a partial fix to the problem; first-class Conan support for components will be required for a full fix.